### PR TITLE
Update resources-document.adoc

### DIFF
--- a/src/main/asciidoc/resources-document.adoc
+++ b/src/main/asciidoc/resources-document.adoc
@@ -93,7 +93,7 @@ GET {API}/employers/93017373[^] HTTP/1.1
 
 3+|​​​Parameters
 
-|`employerId`|path-param|CBE enterprise number uniquely identifying the employer.
+|`employerId`|path-param|NNSO number uniquely identifying the employer.
 
 3+|Response
 


### PR DESCRIPTION
First you inform to use the standard business name iso `id` for e.g. CBE enterprise identifier:
"`enterpriseNumber` is a standard business name for the CBE enterprise identifier, so it should be used instead of `id`:"

Then you use employerId iso "enterpriseNumber" here:
"|`employerId`|path-param|CBE enterprise number uniquely identifying the employer."

At last in the example, 
emplyoerId=93017373=nnsoNbr 
**<>** cbeNbr = 202239951 

"{
  "self": "{API}/employers/93017373[/employers/93017373^]",
  "name": "Belgacom",
  "nssoNbr": 93017373,
  "company": {
    "cbeNbr": 202239951,
    "href": "{API}/companies/202239951[/companies/202239951^]"
  }
}"

That doesn't seem to comply with saying the cbeNbr is used as identifier for the employers collection, as the Document containers a cbeNbr property with a different value.
Therefore it seems more logical / less confusing to change the description as proposed in the merge request.